### PR TITLE
feat(playwright): Added `uri_type` configuration item, allowing users to choose to connect using either the `ws` or `cdp` method.

### DIFF
--- a/provider/playwright.yaml
+++ b/provider/playwright.yaml
@@ -26,3 +26,22 @@ credentials_for_provider:
       zh_Hans: 请输入Playwright URI
     required: true
     type: secret-input
+  uri_type:
+    help:
+      en_US: Choose to use ws or cdp to connect
+      zh_Hans: 选择使用 ws 还是 cdp 连接
+    label:
+      en_US: URI Type
+      zh_Hans: URI 类型
+    required: true
+    type: select
+    options:
+      - value: ws
+        label:
+          en_US: ws
+          zh_Hans: ws
+      - value: cdp
+        label:
+          en_US: cdp
+          zh_Hans: cdp
+    default: ws

--- a/tools/playwright.py
+++ b/tools/playwright.py
@@ -1,14 +1,17 @@
 from collections.abc import Generator
-from typing import Any
+from typing import Any, Literal
 
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 from playwright.sync_api import sync_playwright
 
 
-def run_playwright(uri: str, commands: str) -> str | bytes:
+def run_playwright(uri: str, commands: str, uri_type: Literal["ws", "cdp"]) -> str | bytes:
     with sync_playwright() as p:
-        browser = p.chromium.connect(ws_endpoint=uri, timeout=3000)
+        if uri_type == "ws":
+            browser = p.chromium.connect(ws_endpoint=uri, timeout=3000)
+        else:
+            browser = p.chromium.connect_over_cdp(endpoint_url=uri, timeout=3000)
         local_vars = {"browser": browser}
         exec(commands, {}, local_vars)
         result = local_vars.get("result")
@@ -20,7 +23,7 @@ class PlaywrightTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage]:
         commands = tool_parameters.get("script")
         result = run_playwright(
-            self.runtime.credentials.get("playwright_uri"), commands
+            self.runtime.credentials.get("playwright_uri"), commands, self.runtime.credentials.get("uri_type")
         )
         if isinstance(result, str):
             yield self.create_text_message(result)


### PR DESCRIPTION
Sometimes, it is desired to use the desktop browser to connect via the Chrome DevTools Protocol (CDP), which facilitates visualizing the operation process and debugging scripts. Therefore, a CDP connection method has been added to allow users to make their own choices.