### PR TITLE
Add MIT license information to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 **Version:** 0.0.1  
 **Type:** tool  
 **Repo&Issue:** [https://github.com/hjlarry/dify-plugin-playwright](https://github.com/hjlarry/dify-plugin-playwright)  
+**License:** MIT
 
 A tool can be used to automate the browser with playwright script.
 


### PR DESCRIPTION
The MIT license information has been added to the README.md. 
Including this information helps users understand the licensing terms, ensuring proper usage and attribution.